### PR TITLE
18 feature offlineplayer start raids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# OfflinePlayers-Reworked 1.0.5 (MC 1.21)
+
+**Updates:**
+- Added check to see if item is consumable which includes bottles & milk. 
+- Added a check that makes sure that no ominous effect is active. Without this check it can reset the raid effect causing no raid to start.
+
 # OfflinePlayers-Reworked 1.0.4 (MC 1.21)
 
 **Updates:**

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21+build.9
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.0.4
+mod_version=1.0.5
 maven_group=com.misterfish
 archives_base_name=offlineplayersreworked
 


### PR DESCRIPTION
Added check to see if item is consumable which includes bottles & milk. 
Added a check that makes sure that no ominous effect is active. Without this check it can reset the raid effect causing no raid to start.
